### PR TITLE
feat: Generate custom tokens

### DIFF
--- a/src/features/services/components/create-token-modal.tsx
+++ b/src/features/services/components/create-token-modal.tsx
@@ -1,0 +1,167 @@
+import {
+  Flex,
+  Grid,
+  GridItem,
+  HStack,
+  Button,
+  Modal,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Icon,
+  Input,
+  Popover,
+  PopoverTrigger,
+  PopoverBody,
+  PopoverContent,
+} from "@liftedinit/ui";
+import { FiInfo } from "react-icons/fi";
+import { useAccountsStore } from "features/accounts";
+import { useForm, SubmitHandler, Controller } from "react-hook-form";
+
+interface CreateTokenInputs {
+  name: string;
+  symbol: string;
+  amount: string;
+  address: string;
+}
+
+export function CreateTokenModal({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) {
+  const {
+    control,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<CreateTokenInputs>();
+  const account = useAccountsStore((s) => s.byId.get(s.activeId));
+  const address = account?.address ?? "";
+
+  // @TODO: Send the data somewhere
+  const onSubmit: SubmitHandler<CreateTokenInputs> = ({
+    name,
+    symbol,
+    amount,
+  }) =>
+    window.alert(
+      JSON.stringify(
+        {
+          name,
+          symbol: symbol.toUpperCase(),
+          amount: parseFloat(amount),
+          address,
+        },
+        null,
+        2
+      )
+    );
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal.Header>Create Token</Modal.Header>
+      <Modal.Body>
+        <Grid templateColumns="repeat(5,1fr)" gap={9}>
+          <GridItem colSpan={3}>
+            <FormControl isInvalid={!!errors.name}>
+              <FormLabel htmlFor="name">Name</FormLabel>
+              <Controller
+                name="name"
+                control={control}
+                rules={{
+                  required: true,
+                  maxLength: 20,
+                  pattern: /^[A-Za-z]+$/i,
+                }}
+                render={({ field }) => (
+                  <Input placeholder="MyToken" {...field} />
+                )}
+              />
+              {errors.name && (
+                <FormErrorMessage>Must contain only letters.</FormErrorMessage>
+              )}
+            </FormControl>
+          </GridItem>
+          <GridItem colSpan={2}>
+            <FormControl isInvalid={!!errors.symbol}>
+              <FormLabel htmlFor="Symbol">Symbol</FormLabel>
+              <Controller
+                name="symbol"
+                control={control}
+                rules={{
+                  required: true,
+                  pattern: /^[A-Z]{3,5}$/i,
+                }}
+                render={({ field }) => (
+                  <Input
+                    sx={{ textTransform: "uppercase" }}
+                    placeholder="MYT"
+                    {...field}
+                  />
+                )}
+              />
+              {errors.symbol && (
+                <FormErrorMessage>Must be 3 to 5 letters.</FormErrorMessage>
+              )}
+            </FormControl>
+          </GridItem>
+          <GridItem colSpan={2}>
+            <FormControl isInvalid={!!errors.amount}>
+              <FormLabel htmlFor="amount">Amount</FormLabel>
+              <Controller
+                name="amount"
+                control={control}
+                rules={{
+                  required: true,
+                  validate: {
+                    isNumber: (v) => !Number.isNaN(parseFloat(v)),
+                    isPositive: (v) => parseFloat(v) > 0,
+                  },
+                }}
+                render={({ field }) => (
+                  <Input type="number" placeholder="100000000" {...field} />
+                )}
+              />
+              {errors.amount && (
+                <FormErrorMessage>Must be a positive number.</FormErrorMessage>
+              )}
+            </FormControl>
+          </GridItem>
+          <GridItem colSpan={3}>
+            <FormControl>
+              <HStack>
+                <FormLabel htmlFor="address">Destination Address</FormLabel>
+                <Popover trigger="hover">
+                  <PopoverTrigger>
+                    <Icon as={FiInfo} />
+                  </PopoverTrigger>
+                  <PopoverContent bg="brand.teal.700" color="white" p={3}>
+                    <PopoverBody>
+                      The destination address is the current user and cannot be
+                      changed at this time.
+                    </PopoverBody>
+                  </PopoverContent>
+                </Popover>
+              </HStack>
+              <Input isDisabled value={address} />
+            </FormControl>
+          </GridItem>
+        </Grid>
+      </Modal.Body>
+      <Modal.Footer>
+        <Flex justifyContent="flex-end" w="full">
+          <Button
+            onClick={handleSubmit(onSubmit)}
+            width={{ base: "full", md: "auto" }}
+            colorScheme="brand.teal"
+          >
+            Create
+          </Button>
+        </Flex>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/features/services/components/index.ts
+++ b/src/features/services/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./service";
 export * from "./ledger-settings";
+export * from "./create-token-modal";

--- a/src/features/services/components/ledger-settings.tsx
+++ b/src/features/services/components/ledger-settings.tsx
@@ -2,6 +2,8 @@ import {
   Alert,
   AlertIcon,
   Box,
+  Button,
+  Flex,
   Heading,
   Table,
   Tbody,
@@ -10,9 +12,11 @@ import {
   Td,
   Th,
   Progress,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { AddressText } from "@liftedinit/ui";
 import { useTokenList } from "../queries";
+import { CreateTokenModal } from "../components";
 
 interface Token {
   name: string;
@@ -34,6 +38,8 @@ function TokenRow({ name, symbol, address }: Token) {
 
 export function LedgerSettings() {
   const { data, isError, isLoading } = useTokenList();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
   if (isLoading) {
     return <Progress isIndeterminate />;
   }
@@ -46,20 +52,28 @@ export function LedgerSettings() {
     );
   }
   return (
-    <Box p={6} bg="white" mt={9} boxShadow="xl">
-      <Heading size="md" mb={6}>
-        All Tokens
-      </Heading>
-      <Table>
-        <Thead>
-          <Tr>
-            <Th>Symbol</Th>
-            <Th>Name</Th>
-            <Th>Address</Th>
-          </Tr>
-        </Thead>
-        <Tbody>{data.map(TokenRow)}</Tbody>
-      </Table>
-    </Box>
+    <>
+      <Box p={6} bg="white" mt={9} boxShadow="xl">
+        <Heading size="md" mb={6}>
+          All Tokens
+        </Heading>
+        <Table>
+          <Thead>
+            <Tr>
+              <Th>Symbol</Th>
+              <Th>Name</Th>
+              <Th>Address</Th>
+            </Tr>
+          </Thead>
+          <Tbody>{data.map(TokenRow)}</Tbody>
+        </Table>
+        <Flex mt={9} justifyContent="flex-end" w="full">
+          <Button width={{ base: "full", md: "auto" }} onClick={onOpen}>
+            Create Token
+          </Button>
+        </Flex>
+      </Box>
+      {isOpen && <CreateTokenModal isOpen={isOpen} onClose={onClose} />}
+    </>
   );
 }


### PR DESCRIPTION
## Description

- [x] Create Token button in Ledger Settings view
- [x] Pop open a modal with the fields specified in the mock-up
- [x] Show more information on hover
- [x] Validate inputs based on the story acceptance criteria

Future PR

- [ ] Submit form data to the network
- [ ] Handle form submission errors
- [ ] Redirect to Ledger Settings and re-fetch token list

## Related Issue

Closes liftedinit/roadmap#21

## Screenshots (if applicable)

**TOKEN LIST**

<img width="989" alt="Screenshot 2022-11-16 at 3 08 03 PM" src="https://user-images.githubusercontent.com/405258/202314070-fb4cce76-1b95-4302-a7db-81367137b771.png">

Now with 100% more "Create Token" buttons.

**CREATE TOKEN MODAL**

<img width="990" alt="Screenshot 2022-11-16 at 3 09 16 PM" src="https://user-images.githubusercontent.com/405258/202314247-17589755-4520-4d83-b71e-17d3db94b00a.png">

**INFO POPOVER**

<img width="993" alt="Screenshot 2022-11-16 at 2 58 54 PM" src="https://user-images.githubusercontent.com/405258/202314172-e469eb5f-2388-4265-976d-63ddd932e230.png">

**FIELD VALIDATION**

<img width="990" alt="Screenshot 2022-11-16 at 3 00 08 PM" src="https://user-images.githubusercontent.com/405258/202314317-fc6ef9a3-f588-4c05-b3ff-299787f8f19f.png">

**SUBMIT**

<img width="990" alt="Screenshot 2022-11-16 at 3 05 30 PM" src="https://user-images.githubusercontent.com/405258/202314354-cce34b38-5b31-43cd-8573-0733d803c2d6.png">

Not connected to a back-end yet. Just uses a `window.alert`.