### PR TITLE
feat: add method to read and show keys in the data table from state

### DIFF
--- a/src/features/services/components/data-settings.tsx
+++ b/src/features/services/components/data-settings.tsx
@@ -7,38 +7,18 @@ import {
   Tbody,
   Thead,
   Tr,
-  Td,
   Th,
   useDisclosure,
 } from "@liftedinit/ui";
 import { PutValueModal } from "../components";
 import { useAccountsStore } from "features/accounts";
 import { ANON_IDENTITY } from "@liftedinit/many-js";
-// import { useDataServiceStore } from "features/services";
-
-interface KVData {
-  key: string;
-  value: string;
-  tag: string;
-}
-
-// eslint-disable-next-line
-function KVDataRow({ key, value, tag }: KVData) {
-  return (
-    <Tr key={key}>
-      <Td>{key}</Td>
-      <Td>{value}</Td>
-      <Td>{tag}</Td>
-    </Tr>
-  );
-}
+import { KVDataRow} from "./kvdatarow";
 
 export function DataSettings() {
   const account = useAccountsStore((s) => s.byId.get(s.activeId));
-  // @TODO: Fetch all the keys
-  // const keys = useDataServiceStore((s) => s.keys);
   const { isOpen, onOpen, onClose } = useDisclosure();
-
+  
   return (
     <>
       <Box p={6} bg="white" mt={9} boxShadow="xl">
@@ -54,7 +34,7 @@ export function DataSettings() {
               <Th>Edit</Th>
             </Tr>
           </Thead>
-          <Tbody></Tbody>
+          <Tbody>{KVDataRow()}</Tbody>
         </Table>
         {account?.address !== ANON_IDENTITY && (
           <Flex mt={9} justifyContent="flex-end" w="full">

--- a/src/features/services/components/kvdatarow.tsx
+++ b/src/features/services/components/kvdatarow.tsx
@@ -1,0 +1,21 @@
+import {
+  Tr,
+  Td,
+} from "@liftedinit/ui";
+import { useDataServiceStore } from "features/services";
+
+export function KVDataRow() {
+ const keys = useDataServiceStore((s) => s.keys);
+ const kvlist = keys.map((key) => {
+ return (
+  <Tr>
+    <Td>{key}</Td>
+    <Td></Td>
+    <Td></Td>
+  </Tr>
+ ); 
+  });
+  return kvlist;
+}
+
+export default KVDataRow;


### PR DESCRIPTION
## Description

Partial Work, Add a method to show the keys in the table on the data-settings page to show arbitrary data (KVStore).

## Related Issue
https://github.com/liftedinit/roadmap/issues/17

Fixes # (issue)

## Testing

## Breaking Changes (if applicable)

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/1266065/214302880-2f811875-bd8a-4542-b7ea-28d029dc2e05.png)

## Checklist:

- [x] I have read and followed the CONTRIBUTING guidelines for this project.
- [x] I have added or updated tests and they pass.
- [x] I have added or updated documentation and it is accurate.
- [x] I have noted any breaking changes in this module or downstream modules.
