### PR TITLE
fix: Store unique keys

### DIFF
--- a/src/features/services/store.ts
+++ b/src/features/services/store.ts
@@ -130,7 +130,8 @@ export const useDataServiceStore = create<
   persist(
     (set) => ({
       keys: [],
-      addKey: (key: string) => set((s) => ({ keys: [...s.keys, key] })),
+      addKey: (key: string) =>
+        set((s) => ({ keys: [...new Set([...s.keys, key])] })),
       delKey: (key: string) =>
         set((s) => ({ keys: s.keys.filter((k) => k !== key) })),
     }),


### PR DESCRIPTION
As demoed today, even though keys are unique in the back-end, the front-end cache doesn't check for duplicates.
