### PR TITLE
fix: Token names should allow numbers and spaces

### DIFF
--- a/src/features/services/ledger/components/create-token-modal.tsx
+++ b/src/features/services/ledger/components/create-token-modal.tsx
@@ -81,14 +81,16 @@ export function CreateTokenModal({
                 rules={{
                   required: true,
                   maxLength: 20,
-                  pattern: /^[A-Za-z ]+$/i,
+                  pattern: /^[\w ]+$/i,
                 }}
                 render={({ field }) => (
                   <Input placeholder="MyToken" {...field} />
                 )}
               />
               {errors.name && (
-                <FormErrorMessage>Must contain only letters.</FormErrorMessage>
+                <FormErrorMessage>
+                  Must contain only letters, numbers, and spaces.
+                </FormErrorMessage>
               )}
             </FormControl>
           </GridItem>


### PR DESCRIPTION
<img width="587" alt="Screenshot 2023-05-31 at 11 51 15 AM" src="https://github.com/liftedinit/gwen/assets/405258/d545498b-8e19-44d2-a568-ba16d9971066">

<img width="1368" alt="Screenshot 2023-05-31 at 11 51 30 AM" src="https://github.com/liftedinit/gwen/assets/405258/53c7038c-74a2-48fe-b396-53f168a04db4">

Fixes #37 