### PR TITLE
build: Add code coverage and badge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@5.1.0
+  codecov: codecov/codecov@3.2.4
 
 jobs:
   test-build:
@@ -18,7 +19,8 @@ jobs:
       - install-packages
       - run:
           name: Run tests
-          command: npm run test
+          command: npm run test -- --coverage
+      - codecov/upload
       - run: echo 'export NODE_OPTIONS="--max-old-space-size=4096"' >> $BASH_ENV
       - run:
           name: Build staging app

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Gwen
 
+[![coverage](https://img.shields.io/codecov/c/gh/liftedinit/gwen)](https://app.codecov.io/gh/liftedinit/gwen)
+
 Gwen is a CPanel-like dashboard for managing clusters supporting the [Many protocol](https://github.com/many-protocol/specification) built in React.
 
 Read more about this project and its goals on [Medium](https://medium.com/@TheLiftedInitiative/removing-obstacles-to-adoption-5782757e4a0b).


### PR DESCRIPTION
We may have to merge this one "blind" because I don't think it will have any effect until it's in the upstream repo.

Closes #64 .