### PR TITLE
fix: Disable Hardware Authenticator identities for unsupported Neighborhoods

### DIFF
--- a/src/api/neighborhoods/provider.tsx
+++ b/src/api/neighborhoods/provider.tsx
@@ -36,10 +36,11 @@ export function NeighborhoodProvider({ children }: { children: ReactNode }) {
   const account = useAccountsStore((s) => s.byId.get(s.activeId))!;
 
   const url = neighborhood.url;
-  const anonymous = new AnonymousIdentity();
-  const identity = account?.identity ?? anonymous;
 
   const context = useMemo(() => {
+    const anonymous = new AnonymousIdentity();
+    const identity = account?.identity ?? anonymous;
+
     const query = new Network(url, anonymous);
     const command = new Network(url, identity);
     [query, command].forEach((network) =>
@@ -56,7 +57,7 @@ export function NeighborhoodProvider({ children }: { children: ReactNode }) {
       ])
     );
     return { query, command, services: new Set<string>() };
-  }, [identity, url]);
+  }, [account, url]);
 
   useEffect(() => {
     async function updateServices() {
@@ -72,7 +73,7 @@ export function NeighborhoodProvider({ children }: { children: ReactNode }) {
         );
     }
     updateServices();
-  }, [url]);
+  }, [context]);
 
   return (
     <NeighborhoodContext.Provider value={context}>

--- a/src/api/neighborhoods/provider.tsx
+++ b/src/api/neighborhoods/provider.tsx
@@ -64,10 +64,15 @@ export function NeighborhoodProvider({ children }: { children: ReactNode }) {
       if (!context.query || !context.query.base) {
         return;
       }
-      const { endpoints } = await context.query.base.endpoints();
-      const updated = endpoints
-        .map((endpoint: string) => endpoint.split(".")[0])
-        .reduce((acc: Set<string>, val: string) => acc.add(val), new Set());
+      const updated = new Set<string>();
+      try {
+        const { endpoints } = await context.query.base.endpoints();
+        endpoints
+          .map((endpoint: string) => endpoint.split(".")[0])
+          .forEach((service: string) => updated.add(service));
+      } catch (error) {
+        console.error(`Couldn't update services: ${(error as Error).message}`);
+      }
       setServices(updated);
     }
     updateServices();

--- a/src/api/neighborhoods/provider.tsx
+++ b/src/api/neighborhoods/provider.tsx
@@ -48,3 +48,21 @@ export function NeighborhoodProvider({ children }: { children: ReactNode }) {
     </NeighborhoodContext.Provider>
   );
 }
+
+export async function getServices(
+  neighborhood: Network | undefined
+): Promise<Set<string>> {
+  const { endpoints } = await neighborhood?.base.endpoints();
+  const services = endpoints
+    .map((endpoint: string) => endpoint.split(".")[0])
+    .reduce((acc: Set<string>, val: string) => acc.add(val), new Set<string>());
+  return services;
+}
+
+export async function hasService(
+  neighborhood: Network | undefined,
+  service: string
+): Promise<boolean> {
+  const services = await getServices(neighborhood);
+  return services.has(service);
+}

--- a/src/api/neighborhoods/provider.tsx
+++ b/src/api/neighborhoods/provider.tsx
@@ -52,7 +52,10 @@ export function NeighborhoodProvider({ children }: { children: ReactNode }) {
 export async function getServices(
   neighborhood: Network | undefined
 ): Promise<Set<string>> {
-  const { endpoints } = await neighborhood?.base.endpoints();
+  if (!neighborhood || !neighborhood.base) {
+    return new Set<string>();
+  }
+  const { endpoints } = await neighborhood.base.endpoints();
   const services = endpoints
     .map((endpoint: string) => endpoint.split(".")[0])
     .reduce((acc: Set<string>, val: string) => acc.add(val), new Set<string>());

--- a/src/features/accounts/api/create-account.ts
+++ b/src/features/accounts/api/create-account.ts
@@ -3,8 +3,7 @@ import {
   AccountMultisigArgument,
   CreateAccountResponse,
 } from "@liftedinit/many-js";
-import { NeighborhoodContext } from "api/neighborhoods";
-import { useContext } from "react";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { useMutation } from "react-query";
 import { accountLedgerFeature, accountMultisigFeature } from "../types";
 
@@ -20,7 +19,7 @@ export type CreateAccountFormData = {
 };
 
 export function useCreateAccount() {
-  const n = useContext(NeighborhoodContext);
+  const { command: n } = useNeighborhoodContext();
   return useMutation<CreateAccountResponse, Error, CreateAccountFormData>(
     async (vars: CreateAccountFormData) => {
       const name = vars.accountSettings.name;

--- a/src/features/accounts/api/get-account-info.ts
+++ b/src/features/accounts/api/get-account-info.ts
@@ -3,13 +3,12 @@ import {
   AccountRole,
   GetAccountInfoResponse,
 } from "@liftedinit/many-js";
-import { NeighborhoodContext } from "api/neighborhoods";
-import { useContext } from "react";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { useQuery } from "react-query";
 import { useAccountsStore } from "../stores";
 
 export function useGetAccountInfo(accountAddress?: string) {
-  const n = useContext(NeighborhoodContext);
+  const { query: n } = useNeighborhoodContext();
   const activeIdentity = useAccountsStore((s) => s.byId.get(s.activeId));
   const address = activeIdentity?.address;
 

--- a/src/features/accounts/api/get-webauthn-credential.ts
+++ b/src/features/accounts/api/get-webauthn-credential.ts
@@ -1,5 +1,4 @@
-import { NeighborhoodContext } from "api/neighborhoods";
-import { useContext } from "react";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { useMutation } from "react-query";
 import { RecoverOptions } from "../types";
 
@@ -7,13 +6,13 @@ import { RecoverOptions } from "../types";
  * get webauthn account data from k-v store during import/recovery
  */
 export function useGetWebauthnCredential() {
-  const queryNetwork = useContext(NeighborhoodContext);
+  const { query } = useNeighborhoodContext();
   return useMutation(
     async ({ getFrom, value }: { getFrom: RecoverOptions; value: string }) => {
       const getFn =
         getFrom === RecoverOptions.phrase
-          ? queryNetwork?.idStore.getFromRecallPhrase
-          : queryNetwork?.idStore.getFromAddress;
+          ? query?.idStore.getFromRecallPhrase
+          : query?.idStore.getFromAddress;
       const res = await getFn(value);
       return res;
     }

--- a/src/features/accounts/api/save-webauthn-credential.ts
+++ b/src/features/accounts/api/save-webauthn-credential.ts
@@ -1,10 +1,9 @@
 import { IdStore, Network, WebAuthnIdentity } from "@liftedinit/many-js";
-import { NeighborhoodContext } from "api/neighborhoods";
-import { useContext } from "react";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { useMutation } from "react-query";
 
 export function useSaveWebauthnCredential() {
-  const network = useContext(NeighborhoodContext);
+  const { command } = useNeighborhoodContext();
   return useMutation<
     { phrase: string },
     Error,
@@ -15,7 +14,7 @@ export function useSaveWebauthnCredential() {
       identity: WebAuthnIdentity;
     }
   >(async ({ address, credentialId, cosePublicKey, identity }) => {
-    const n = new Network(network?.url ?? "", identity);
+    const n = new Network(command?.url ?? "", identity);
     n.apply([IdStore]);
     const res = await n?.idStore.store(address, credentialId, cosePublicKey);
     return res;

--- a/src/features/accounts/components/accounts-menu/accounts-menu.tsx
+++ b/src/features/accounts/components/accounts-menu/accounts-menu.tsx
@@ -28,9 +28,9 @@ import {
   useToast,
   VStack,
 } from "@liftedinit/ui";
-import { hasService, NeighborhoodContext } from "api/neighborhoods";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { useAccountsStore } from "features/accounts";
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Account, AccountId } from "../../types";
 import { AddAccountModal } from "./add-account-modal";
 import { EditAccountModal } from "./edit-account-modal";
@@ -69,13 +69,12 @@ export function AccountsMenu() {
   );
 
   const toast = useToast();
-  const neighborhood = useContext(NeighborhoodContext);
+  const { services } = useNeighborhoodContext();
   useEffect(() => {
     (async () => {
       const isWebAuthnIdentity =
         activeAccount?.identity instanceof WebAuthnIdentity;
-      const hasIdStore = await hasService(neighborhood, "idstore");
-      if (isWebAuthnIdentity && !hasIdStore) {
+      if (isWebAuthnIdentity && !services.has("idstore")) {
         setActiveId(0); // reset to Anonymous
         toast({
           status: "warning",
@@ -85,7 +84,7 @@ export function AccountsMenu() {
         });
       }
     })();
-  }, [activeAccount, neighborhood, setActiveId, toast]);
+  }, [activeAccount, services, setActiveId, toast]);
 
   const [editAccount, setEditAccount] = useState<
     [number, Account] | undefined

--- a/src/features/accounts/components/accounts-menu/accounts-menu.tsx
+++ b/src/features/accounts/components/accounts-menu/accounts-menu.tsx
@@ -1,37 +1,39 @@
-import React from "react";
 import {
   AnonymousIdentity,
   ANON_IDENTITY,
   WebAuthnIdentity,
 } from "@liftedinit/many-js";
-import { useAccountsStore } from "features/accounts";
 import {
+  AddressText,
   Box,
   Button,
+  ChevronDownIcon,
   Circle,
+  EditIcon,
   Flex,
   HStack,
   Icon,
   IconButton,
   Menu,
   MenuButton,
-  MenuList,
-  MenuItem,
-  MenuOptionGroup,
   MenuDivider,
+  MenuItem,
+  MenuList,
+  MenuOptionGroup,
   SimpleGrid,
   Text,
-  useDisclosure,
-  VStack,
-  AddressText,
-  ChevronDownIcon,
-  EditIcon,
-  UserIcon,
   UsbIcon,
+  useDisclosure,
+  UserIcon,
+  useToast,
+  VStack,
 } from "@liftedinit/ui";
+import { hasService, NeighborhoodContext } from "api/neighborhoods";
+import { useAccountsStore } from "features/accounts";
+import { useContext, useEffect, useState } from "react";
+import { Account, AccountId } from "../../types";
 import { AddAccountModal } from "./add-account-modal";
 import { EditAccountModal } from "./edit-account-modal";
-import { Account, AccountId } from "../../types";
 
 export type AccountItemWithIdDisplayStrings = [
   AccountId,
@@ -66,7 +68,26 @@ export function AccountsMenu() {
     })
   );
 
-  const [editAccount, setEditAccount] = React.useState<
+  const toast = useToast();
+  const neighborhood = useContext(NeighborhoodContext);
+  useEffect(() => {
+    (async () => {
+      const isWebAuthnIdentity =
+        activeAccount?.identity instanceof WebAuthnIdentity;
+      const hasIdStore = await hasService(neighborhood, "idstore");
+      if (isWebAuthnIdentity && !hasIdStore) {
+        setActiveId(0); // reset to Anonymous
+        toast({
+          status: "warning",
+          title: "Unsupported Identity",
+          description:
+            "Selected Neighborhood does not support Hardware Authenticators",
+        });
+      }
+    })();
+  }, [activeAccount, neighborhood, setActiveId, toast]);
+
+  const [editAccount, setEditAccount] = useState<
     [number, Account] | undefined
   >();
 

--- a/src/features/accounts/components/accounts-menu/add-account-modal.tsx
+++ b/src/features/accounts/components/accounts-menu/add-account-modal.tsx
@@ -10,8 +10,8 @@ import {
   Tabs,
   VStack,
 } from "@liftedinit/ui";
-import { getServices, NeighborhoodContext } from "api/neighborhoods";
-import { Dispatch, ReactNode, useContext, useEffect, useState } from "react";
+import { useNeighborhoodContext } from "api/neighborhoods";
+import { Dispatch, ReactNode, useEffect, useState } from "react";
 import { SocialLogin } from "../social-login";
 import { CreateAccount } from "./create-account";
 import { HardwareAuthenticator } from "./hardware-authenticator";
@@ -44,14 +44,6 @@ export function AddAccountModal({
   const [addMethod, setAddMethod] = useState<AddMethodState>("");
   const [showDefaultFooter, setShowDefaultFooter] = useState<boolean>(true);
 
-  const neighborhood = useContext(NeighborhoodContext);
-  const [services, setServices] = useState<Set<string>>(new Set());
-  useEffect(() => {
-    (async () => {
-      setServices(await getServices(neighborhood));
-    })();
-  }, [neighborhood]);
-
   function onSuccess() {
     onClose();
   }
@@ -78,7 +70,6 @@ export function AddAccountModal({
               setAddMethod(methodType);
             }}
             onSuccess={onSuccess}
-            services={services}
           />
         </ScaleFade>
       )}
@@ -125,11 +116,9 @@ enum TabNames {
 function AddAccountMethods({
   onAddMethodClick,
   onSuccess,
-  services,
 }: {
   onAddMethodClick: (method: AddAccountMethodTypes) => void;
   onSuccess: () => void;
-  services: Set<string>;
 }) {
   const [activeTab, setActiveTab] = useState(TabNames.create);
   const tabs = ["Create New", "Import"];
@@ -154,16 +143,10 @@ function AddAccountMethods({
 
         <SocialLogin onSuccess={onSuccess} />
         {activeTab === TabNames.create && (
-          <CreateAccountOptions
-            onAddMethodClick={onAddMethodClick}
-            services={services}
-          />
+          <CreateAccountOptions onAddMethodClick={onAddMethodClick} />
         )}
         {activeTab === TabNames.import && (
-          <ImportAcountOptions
-            onAddMethodClick={onAddMethodClick}
-            services={services}
-          />
+          <ImportAcountOptions onAddMethodClick={onAddMethodClick} />
         )}
       </Modal.Body>
       <Modal.Footer />
@@ -187,11 +170,10 @@ const createCards = [
 
 function CreateAccountOptions({
   onAddMethodClick,
-  services,
 }: {
   onAddMethodClick: (method: AddAccountMethodTypes) => void;
-  services: Set<string>;
 }) {
+  const { services } = useNeighborhoodContext();
   return (
     <VStack alignItems="flex-start" w="full">
       {createCards
@@ -230,11 +212,11 @@ const importCards = [
 ];
 function ImportAcountOptions({
   onAddMethodClick,
-  services,
 }: {
   onAddMethodClick: (method: AddAccountMethodTypes) => void;
-  services: Set<string>;
 }) {
+  const { services } = useNeighborhoodContext();
+
   return (
     <VStack alignItems="flex-start" w="full">
       {importCards

--- a/src/features/accounts/components/accounts-menu/add-account-modal.tsx
+++ b/src/features/accounts/components/accounts-menu/add-account-modal.tsx
@@ -1,21 +1,22 @@
-import React from "react";
 import {
   Box,
   Button,
+  ChevronRightIcon,
   Flex,
+  Modal,
   ScaleFade,
   Tab,
-  Tabs,
   TabList,
+  Tabs,
   VStack,
-  ChevronRightIcon,
-  Modal,
 } from "@liftedinit/ui";
-import { SeedWords } from "./seed-words";
-import { CreateAccount } from "./create-account";
-import { PemFile } from "./pem-file";
-import { HardwareAuthenticator } from "./hardware-authenticator";
+import { getServices, NeighborhoodContext } from "api/neighborhoods";
+import { Dispatch, ReactNode, useContext, useEffect, useState } from "react";
 import { SocialLogin } from "../social-login";
+import { CreateAccount } from "./create-account";
+import { HardwareAuthenticator } from "./hardware-authenticator";
+import { PemFile } from "./pem-file";
+import { SeedWords } from "./seed-words";
 
 export enum AddAccountMethodTypes {
   createSeed,
@@ -29,7 +30,7 @@ export enum AddAccountMethodTypes {
 export const toastTitle = "Add Account";
 export type AddMethodState = AddAccountMethodTypes | "";
 export type AddAccountMethodProps = {
-  setAddMethod: React.Dispatch<AddMethodState>;
+  setAddMethod: Dispatch<AddMethodState>;
   onSuccess: () => void;
 };
 
@@ -40,9 +41,16 @@ export function AddAccountModal({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const [addMethod, setAddMethod] = React.useState<AddMethodState>("");
-  const [showDefaultFooter, setShowDefaultFooter] =
-    React.useState<boolean>(true);
+  const [addMethod, setAddMethod] = useState<AddMethodState>("");
+  const [showDefaultFooter, setShowDefaultFooter] = useState<boolean>(true);
+
+  const neighborhood = useContext(NeighborhoodContext);
+  const [services, setServices] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    (async () => {
+      setServices(await getServices(neighborhood));
+    })();
+  }, [neighborhood]);
 
   function onSuccess() {
     onClose();
@@ -50,7 +58,7 @@ export function AddAccountModal({
 
   const hasAddMethod = typeof addMethod === "number";
 
-  React.useEffect(() => {
+  useEffect(() => {
     setAddMethod("");
   }, [isOpen]);
 
@@ -70,6 +78,7 @@ export function AddAccountModal({
               setAddMethod(methodType);
             }}
             onSuccess={onSuccess}
+            services={services}
           />
         </ScaleFade>
       )}
@@ -86,13 +95,13 @@ export function AddAccountModal({
           )}
           {(addMethod === AddAccountMethodTypes.importAuthenticator ||
             addMethod === AddAccountMethodTypes.createAuthenticator) && (
-            <HardwareAuthenticator
-              addMethod={addMethod}
-              setAddMethod={setAddMethod}
-              onSuccess={onSuccess}
-              setShowDefaultFooter={setShowDefaultFooter}
-            />
-          )}
+              <HardwareAuthenticator
+                addMethod={addMethod}
+                setAddMethod={setAddMethod}
+                onSuccess={onSuccess}
+                setShowDefaultFooter={setShowDefaultFooter}
+              />
+            )}
           {showDefaultFooter && (
             <Modal.Footer>
               <Flex justifyContent="flex-end">
@@ -116,11 +125,13 @@ enum TabNames {
 function AddAccountMethods({
   onAddMethodClick,
   onSuccess,
+  services,
 }: {
   onAddMethodClick: (method: AddAccountMethodTypes) => void;
   onSuccess: () => void;
+  services: Set<string>;
 }) {
-  const [activeTab, setActiveTab] = React.useState(TabNames.create);
+  const [activeTab, setActiveTab] = useState(TabNames.create);
   const tabs = ["Create New", "Import"];
   return (
     <>
@@ -143,10 +154,16 @@ function AddAccountMethods({
 
         <SocialLogin onSuccess={onSuccess} />
         {activeTab === TabNames.create && (
-          <CreateAccountOptions onAddMethodClick={onAddMethodClick} />
+          <CreateAccountOptions
+            onAddMethodClick={onAddMethodClick}
+            services={services}
+          />
         )}
         {activeTab === TabNames.import && (
-          <ImportAcountOptions onAddMethodClick={onAddMethodClick} />
+          <ImportAcountOptions
+            onAddMethodClick={onAddMethodClick}
+            services={services}
+          />
         )}
       </Modal.Body>
       <Modal.Footer />
@@ -164,26 +181,31 @@ const createCards = [
     label: "Hardware Authenticator",
     title: "create new with hardware authenticator",
     onClickArg: AddAccountMethodTypes.createAuthenticator,
+    requires: "idstore",
   },
 ];
 
 function CreateAccountOptions({
   onAddMethodClick,
+  services,
 }: {
   onAddMethodClick: (method: AddAccountMethodTypes) => void;
+  services: Set<string>;
 }) {
   return (
     <VStack alignItems="flex-start" w="full">
-      {createCards.map((c, idx) => {
-        return (
-          <AddAccountCard
-            key={idx}
-            label={c.label}
-            title={c.title}
-            onClick={() => onAddMethodClick(c.onClickArg)}
-          />
-        );
-      })}
+      {createCards
+        .filter((c) => !c.requires || services.has(c.requires))
+        .map((c, idx) => {
+          return (
+            <AddAccountCard
+              key={idx}
+              label={c.label}
+              title={c.title}
+              onClick={() => onAddMethodClick(c.onClickArg)}
+            />
+          );
+        })}
     </VStack>
   );
 }
@@ -203,25 +225,30 @@ const importCards = [
     label: "Hardware Authenticator",
     title: "import with hardware authenticator",
     onClickArg: AddAccountMethodTypes.importAuthenticator,
+    requires: "idstore",
   },
 ];
 function ImportAcountOptions({
   onAddMethodClick,
+  services,
 }: {
   onAddMethodClick: (method: AddAccountMethodTypes) => void;
+  services: Set<string>;
 }) {
   return (
     <VStack alignItems="flex-start" w="full">
-      {importCards.map((c, idx) => {
-        return (
-          <AddAccountCard
-            key={idx}
-            label={c.label}
-            title={c.title}
-            onClick={() => onAddMethodClick(c.onClickArg)}
-          />
-        );
-      })}
+      {importCards
+        .filter((c) => !c.requires || services.has(c.requires))
+        .map((c, idx) => {
+          return (
+            <AddAccountCard
+              key={idx}
+              label={c.label}
+              title={c.title}
+              onClick={() => onAddMethodClick(c.onClickArg)}
+            />
+          );
+        })}
     </VStack>
   );
 }
@@ -231,7 +258,7 @@ function AddAccountCard({
   title,
   onClick,
 }: {
-  label: string | React.ReactNode;
+  label: string | ReactNode;
   title?: string;
   onClick: () => void;
 }) {

--- a/src/pages/services/blocks/blocks.tsx
+++ b/src/pages/services/blocks/blocks.tsx
@@ -6,14 +6,13 @@ import {
   Box,
   Heading,
 } from "@liftedinit/ui";
-import { NeighborhoodContext } from "api/neighborhoods";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { useBlockchainInfoQuery } from "api/services";
-import { useContext } from "react";
 import { replacer } from "shared";
 import { Breadcrumbs } from "../breadcrumbs";
 
 export function Blocks() {
-  const neighborhood = useContext(NeighborhoodContext);
+  const { query: neighborhood } = useNeighborhoodContext();
   const { data } = useBlockchainInfoQuery(neighborhood);
 
   return (

--- a/src/pages/services/compute/close-deployment-dialog.tsx
+++ b/src/pages/services/compute/close-deployment-dialog.tsx
@@ -8,9 +8,9 @@ import {
   useDisclosure,
   useToast,
 } from "@liftedinit/ui";
-import { NeighborhoodContext } from "api/neighborhoods";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { useCloseDeployment } from "api/services";
-import { useContext, useRef } from "react";
+import { useRef } from "react";
 
 export function CloseDeploymentDialog({
   dseq,
@@ -19,7 +19,7 @@ export function CloseDeploymentDialog({
   dseq: number;
   children: (onOpen: () => void) => void;
 }) {
-  const neighborhood = useContext(NeighborhoodContext);
+  const { command: neighborhood } = useNeighborhoodContext();
   const toast = useToast();
   const {
     mutate: doCloseDeployment,

--- a/src/pages/services/compute/compute.tsx
+++ b/src/pages/services/compute/compute.tsx
@@ -9,16 +9,15 @@ import {
   useDisclosure,
 } from "@liftedinit/ui";
 import { useAccountsStore } from "features/accounts";
-import { Breadcrumbs } from "../breadcrumbs";
-import { DeploymentTable } from "./deployment-table";
-import { CreateDeploymentModal } from "./create-deployment-modal";
-import { useContext } from "react";
-import { NeighborhoodContext } from "../../../api/neighborhoods";
+import { useNeighborhoodContext } from "../../../api/neighborhoods";
 import { useListDeployments } from "../../../api/services";
+import { Breadcrumbs } from "../breadcrumbs";
+import { CreateDeploymentModal } from "./create-deployment-modal";
+import { DeploymentTable } from "./deployment-table";
 
 export function Compute() {
   const account = useAccountsStore((s) => s.byId.get(s.activeId));
-  const neighborhood = useContext(NeighborhoodContext);
+  const { query: neighborhood } = useNeighborhoodContext();
 
   // const [keyvalue, setKeyvalue] = useState({ key: "", value: "" });
 

--- a/src/pages/services/compute/create-deployment-modal.tsx
+++ b/src/pages/services/compute/create-deployment-modal.tsx
@@ -13,9 +13,8 @@ import {
   Select,
   useToast,
 } from "@liftedinit/ui";
-import { NeighborhoodContext } from "api/neighborhoods";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { useCreateDeployment } from "api/services";
-import { useContext } from "react";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
 
 const Regions = ["us-east", "us-west"];
@@ -53,7 +52,7 @@ export function CreateDeploymentModal({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const neighborhood = useContext(NeighborhoodContext);
+  const { command: neighborhood } = useNeighborhoodContext();
   const {
     mutate: doCreateDeployment,
     error,

--- a/src/pages/services/data/data.tsx
+++ b/src/pages/services/data/data.tsx
@@ -1,26 +1,26 @@
-import {ANON_IDENTITY} from "@liftedinit/many-js";
-import {Box, Button, Flex, Heading, useDisclosure} from "@liftedinit/ui";
-import {NeighborhoodContext} from "api/neighborhoods";
+import { ANON_IDENTITY } from "@liftedinit/many-js";
+import { Box, Button, Flex, Heading, useDisclosure } from "@liftedinit/ui";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import {
   combineData,
   useGetValues,
   useListKeys,
   useQueryValues,
 } from "api/services";
-import {useAccountsStore} from "features/accounts";
-import {useContext, useState} from "react";
-import {Breadcrumbs} from "../breadcrumbs";
-import {DataTable} from "./data-table";
-import {PutValueModal} from "./put-value-modal";
+import { useAccountsStore } from "features/accounts";
+import { useState } from "react";
+import { Breadcrumbs } from "../breadcrumbs";
+import { DataTable } from "./data-table";
+import { PutValueModal } from "./put-value-modal";
 
 export function Data() {
   const account = useAccountsStore((s) => s.byId.get(s.activeId));
-  const neighborhood = useContext(NeighborhoodContext);
-  const {isOpen, onOpen, onClose} = useDisclosure();
-  const [keyvalue, setKeyvalue] = useState({key: "", value: ""});
+  const { query: neighborhood } = useNeighborhoodContext();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [keyvalue, setKeyvalue] = useState({ key: "", value: "" });
 
   const list = useListKeys(neighborhood, account?.address.toString());
-  const all_keys = list.flatMap(item => item.data?.keys || []);
+  const all_keys = list.flatMap((item) => item.data?.keys || []);
   const values = useGetValues(neighborhood, all_keys);
   const queries = useQueryValues(neighborhood, all_keys);
   const data = combineData([...values, ...queries]);
@@ -28,7 +28,7 @@ export function Data() {
   return (
     <Box p={6}>
       <Heading>Data</Heading>
-      <Breadcrumbs title="Data"/>
+      <Breadcrumbs title="Data" />
 
       <DataTable
         data={data}
@@ -39,9 +39,9 @@ export function Data() {
       {account?.address !== ANON_IDENTITY && (
         <Flex mt={9} justifyContent="flex-end" w="full">
           <Button
-            width={{base: "full", md: "auto"}}
+            width={{ base: "full", md: "auto" }}
             onClick={() => {
-              setKeyvalue({key: "", value: ""});
+              setKeyvalue({ key: "", value: "" });
               onOpen();
             }}
           >

--- a/src/pages/services/data/delete-key-dialog.tsx
+++ b/src/pages/services/data/delete-key-dialog.tsx
@@ -8,9 +8,9 @@ import {
   useDisclosure,
   useToast,
 } from "@liftedinit/ui";
-import { NeighborhoodContext } from "api/neighborhoods";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { useDisableKey } from "api/services";
-import { useContext, useRef } from "react";
+import { useRef } from "react";
 
 export function DeleteKeyDialog({
   itemKey,
@@ -19,7 +19,7 @@ export function DeleteKeyDialog({
   itemKey: string;
   children: (onOpen: () => void) => void;
 }) {
-  const neighborhood = useContext(NeighborhoodContext);
+  const { command: neighborhood } = useNeighborhoodContext();
   const toast = useToast();
   const { mutate: doDisableKey, error, isError } = useDisableKey(neighborhood);
   const cancelRef = useRef(null);

--- a/src/pages/services/data/mark-immutable-dialog.tsx
+++ b/src/pages/services/data/mark-immutable-dialog.tsx
@@ -8,9 +8,9 @@ import {
   useDisclosure,
   useToast,
 } from "@liftedinit/ui";
-import { NeighborhoodContext } from "api/neighborhoods";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { useMarkImmutable } from "api/services";
-import { useContext, useRef } from "react";
+import { useRef } from "react";
 
 export function MarkImmutableDialog({
   itemKey,
@@ -19,7 +19,7 @@ export function MarkImmutableDialog({
   itemKey: string;
   children: (onOpen: () => void) => void;
 }) {
-  const neighborhood = useContext(NeighborhoodContext);
+  const { command: neighborhood } = useNeighborhoodContext();
   const toast = useToast();
   const {
     mutate: doTransferKey,

--- a/src/pages/services/data/put-value-modal.tsx
+++ b/src/pages/services/data/put-value-modal.tsx
@@ -12,9 +12,8 @@ import {
   Textarea,
   useToast,
 } from "@liftedinit/ui";
-import { NeighborhoodContext } from "api/neighborhoods";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { usePutValue } from "api/services";
-import { useContext } from "react";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
 
 interface PutValueInputs {
@@ -33,7 +32,7 @@ export function PutValueModal({
   itemKey: string;
   itemValue: string;
 }) {
-  const neighborhood = useContext(NeighborhoodContext);
+  const { command: neighborhood } = useNeighborhoodContext();
   const {
     mutate: doPutValue,
     error,

--- a/src/pages/services/ledger/burn-token-modal.tsx
+++ b/src/pages/services/ledger/burn-token-modal.tsx
@@ -12,9 +12,8 @@ import {
   Modal,
   useToast,
 } from "@liftedinit/ui";
-import { NeighborhoodContext } from "api/neighborhoods";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { TokenInfo, useBurnToken } from "api/services";
-import { useContext } from "react";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
 
 interface BurnTokenInputs {
@@ -31,7 +30,7 @@ export function BurnTokenModal({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const neighborhood = useContext(NeighborhoodContext);
+  const { command: neighborhood } = useNeighborhoodContext();
   const {
     mutate: doBurnToken,
     error,

--- a/src/pages/services/ledger/create-token-modal.tsx
+++ b/src/pages/services/ledger/create-token-modal.tsx
@@ -12,10 +12,10 @@ import {
   Modal,
   useToast,
 } from "@liftedinit/ui";
-import { NeighborhoodContext } from "api/neighborhoods";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { useCreateToken } from "api/services";
 import { useAccountsStore } from "features/accounts";
-import { useContext, useEffect } from "react";
+import { useEffect } from "react";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
 
 export interface CreateTokenInputs {
@@ -33,7 +33,7 @@ export function CreateTokenModal({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const neighborhood = useContext(NeighborhoodContext);
+  const { command: neighborhood } = useNeighborhoodContext();
   const {
     mutate: doCreateToken,
     error,

--- a/src/pages/services/ledger/ledger.tsx
+++ b/src/pages/services/ledger/ledger.tsx
@@ -12,10 +12,10 @@ import {
   Spinner,
   useDisclosure,
 } from "@liftedinit/ui";
-import { NeighborhoodContext } from "api/neighborhoods";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { TokenInfo, useTokenInfo } from "api/services";
 import { useAccountsStore } from "features/accounts";
-import { useContext, useState } from "react";
+import { useState } from "react";
 import { Breadcrumbs } from "../breadcrumbs";
 import { BurnTokenModal } from "./burn-token-modal";
 import { CreateTokenModal } from "./create-token-modal";
@@ -25,7 +25,7 @@ import { TokenTable } from "./token-table";
 export function Ledger() {
   const [selectedToken, setSelectedToken] = useState<TokenInfo>();
   const account = useAccountsStore((s) => s.byId.get(s.activeId));
-  const neighborhood = useContext(NeighborhoodContext);
+  const { query: neighborhood } = useNeighborhoodContext();
 
   const {
     isOpen: isMintOpen,

--- a/src/pages/services/ledger/mint-token-modal.tsx
+++ b/src/pages/services/ledger/mint-token-modal.tsx
@@ -12,9 +12,8 @@ import {
   Modal,
   useToast,
 } from "@liftedinit/ui";
-import { NeighborhoodContext } from "api/neighborhoods";
+import { useNeighborhoodContext } from "api/neighborhoods";
 import { TokenInfo, useMintToken } from "api/services";
-import { useContext } from "react";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
 
 export interface MintTokenInputs {
@@ -31,7 +30,7 @@ export function MintTokenModal({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const neighborhood = useContext(NeighborhoodContext);
+  const { command: neighborhood } = useNeighborhoodContext();
   const {
     mutate: doMintToken,
     error,


### PR DESCRIPTION
### Supported Neighborhood

<img width="1728" alt="Screenshot 2023-09-14 at 11 15 27 AM" src="https://github.com/liftedinit/gwen/assets/405258/abbcc91f-9949-4445-8563-e629dff839fb">

### Unsupported Neighborhood

<img width="1728" alt="Screenshot 2023-09-14 at 11 15 37 AM" src="https://github.com/liftedinit/gwen/assets/405258/07a9b451-4ba7-44ed-b9ad-1b78b3da9b16">

### Switching to an Unsupported Neighborhood

<img width="1728" alt="Screenshot 2023-09-14 at 11 22 21 AM" src="https://github.com/liftedinit/gwen/assets/405258/d3dcbf95-ac84-46ec-a215-3ef4b606ac48">

Closes #68 
Closes #42
Closes #69 